### PR TITLE
replaced uint with unsigned int

### DIFF
--- a/ORBITER/src/lib/foundations/graph_theory/Clique/main.cpp
+++ b/ORBITER/src/lib/foundations/graph_theory/Clique/main.cpp
@@ -54,7 +54,7 @@ int main () {
 	// Create the solution storage. The base type of the solution
 	// storage must be the same as data type of the vertex label
 	// in the graph
-	std::vector<std::vector<uint>> solutions;
+	std::vector<std::vector<unsigned int>> solutions;
 
 	// Call the Rainbow Clique finding algorithm
 	RainbowClique::find_cliques(G, solutions);


### PR DESCRIPTION
This PR removes the one instance of "uint" in main.cpp:57 in "/orbiter/ORBITER/src/lib/foundations/graph_theory/Clique/main.cpp" with "unsigned int".

The effect of this can only be tested under windows systems.