### PR TITLE
Add double cover graph construction command

### DIFF
--- a/src/lib/layer5_top_level/applications_in_algebraic_geometry/quartic_curves/quartic_curve_create.cpp
+++ b/src/lib/layer5_top_level/applications_in_algebraic_geometry/quartic_curves/quartic_curve_create.cpp
@@ -801,7 +801,21 @@ void quartic_curve_create::create_quartic_curve_by_normal_form(
 	}
 
 
+	QOG = NEW_OBJECT(quartic_curve_object_with_group);
 
+	if (f_v) {
+		cout << "quartic_curve_create::create_quartic_curve_by_normal_form "
+				"before QOG->init (with NULL group)" << endl;
+	}
+	QOG->init(
+			QCDA,
+			QO,
+			NULL,
+			verbose_level);
+	if (f_v) {
+		cout << "quartic_curve_create::create_quartic_curve_by_normal_form "
+				"after QOG->init" << endl;
+	}
 
 	prefix = "by_normal_form_q" + std::to_string(F->q);
 	label_txt = "by_normal_form_q" + std::to_string(F->q);

--- a/src/lib/layer5_top_level/applications_in_algebraic_geometry/quartic_curves/quartic_curve_object_with_group.cpp
+++ b/src/lib/layer5_top_level/applications_in_algebraic_geometry/quartic_curves/quartic_curve_object_with_group.cpp
@@ -128,6 +128,35 @@ void quartic_curve_object_with_group::export_something(
 				"Written file " << fname << " of size "
 				<< Fio.file_size(fname) << endl;
 	}
+	else if (ST.stringcmp(what, "Kovalevski_incidence_matrix") == 0) {
+
+		fname = fname_base + "_Kovalevski_incidence_matrix.csv";
+
+		int nb_rows = QO->QP->Kovalevski->Incidence_structure_by_flags->nb_rows;
+		int nb_cols = QO->QP->Kovalevski->Incidence_structure_by_flags->nb_cols;
+		int nb_flags = QO->QP->Kovalevski->Incidence_structure_by_flags->nb_flags;
+		int *flags = QO->QP->Kovalevski->Incidence_structure_by_flags->flags;
+
+		int *Incma = new int[nb_rows * nb_cols];
+		int i;
+		for (i = 0; i < nb_rows * nb_cols; i++) {
+			Incma[i] = 0;
+		}
+		for (i = 0; i < nb_flags; i++) {
+			int r = flags[i] / nb_cols;
+			int c = flags[i] % nb_cols;
+			Incma[r * nb_cols + c] = 1;
+		}
+
+		Fio.Csv_file_support->int_matrix_write_csv(
+				fname, Incma, nb_rows, nb_cols);
+
+		cout << "quartic_curve_object_with_group::export_something "
+				"Written file " << fname << " of size "
+				<< Fio.file_size(fname) << endl;
+
+		delete [] Incma;
+	}
 	else {
 		cout << "quartic_curve_object_with_group::export_something "
 				"unrecognized export target: " << what << endl;

--- a/src/lib/layer5_top_level/apps_graph_theory/create_graph.cpp
+++ b/src/lib/layer5_top_level/apps_graph_theory/create_graph.cpp
@@ -708,6 +708,26 @@ void create_graph::init(
 
 	}
 
+	else if (description->f_double_cover) {
+		if (f_v) {
+			cout << "create_graph::init "
+					"f_double_cover" << endl;
+		}
+
+		if (f_v) {
+			cout << "create_graph::init "
+					"before create_double_cover" << endl;
+		}
+		create_double_cover(
+				description->double_cover_label,
+				verbose_level);
+		if (f_v) {
+			cout << "create_graph::init "
+					"after create_double_cover" << endl;
+		}
+
+	}
+
 
 	if (description->f_subset) {
 		if (f_v) {
@@ -2096,6 +2116,69 @@ void create_graph::make_adjacency_bitvector(
 
 	if (f_v) {
 		cout << "create_graph::make_adjacency_bitvector done" << endl;
+	}
+}
+
+
+void create_graph::create_double_cover(
+		std::string &graph_label,
+		int verbose_level)
+{
+	int f_v = (verbose_level >= 1);
+
+	if (f_v) {
+		cout << "create_graph::create_double_cover" << endl;
+		cout << "create_graph::create_double_cover graph_label=" << graph_label << endl;
+	}
+
+	combinatorics::graph_theory::colored_graph *G0;
+
+	G0 = Get_graph(graph_label);
+
+	int n0 = G0->nb_points;
+
+	if (f_v) {
+		cout << "create_graph::create_double_cover "
+				"source graph has " << n0 << " vertices" << endl;
+	}
+
+	int n = 2 * n0 + 1;
+
+	if (f_v) {
+		cout << "create_graph::create_double_cover "
+				"new graph has " << n << " vertices" << endl;
+	}
+
+	N = n;
+	Adj = NEW_int(N * N);
+	Int_vec_zero(Adj, N * N);
+
+	int i, j;
+
+	for (i = 0; i < n0; i++) {
+		for (j = 0; j < n0; j++) {
+			Adj[i * N + j] = G0->is_adjacent(i, j);
+		}
+	}
+
+	for (i = 0; i < n0; i++) {
+		for (j = 0; j < n0; j++) {
+			Adj[(n0 + i) * N + (n0 + j)] = G0->is_adjacent(i, j);
+		}
+	}
+
+	int z = 2 * n0;
+
+	for (i = 0; i < n0; i++) {
+		Adj[z * N + (n0 + i)] = 1;
+		Adj[(n0 + i) * N + z] = 1;
+	}
+
+	label = "double_cover_" + graph_label;
+	label_tex = "{\\rm double\\_cover\\_{" + graph_label + "}}";
+
+	if (f_v) {
+		cout << "create_graph::create_double_cover done" << endl;
 	}
 }
 

--- a/src/lib/layer5_top_level/apps_graph_theory/create_graph_description.cpp
+++ b/src/lib/layer5_top_level/apps_graph_theory/create_graph_description.cpp
@@ -133,6 +133,9 @@ create_graph_description::create_graph_description()
 	//std::string Cayley_graph_group;
 	//std::string Cayley_graph_gens;
 
+	f_double_cover = false;
+	//std::string double_cover_label;
+
 	//std::vector<graph_modification_description> Modifications;
 
 }
@@ -424,6 +427,15 @@ int create_graph_description::read_arguments(
 			}
 		}
 
+		else if (ST.stringcmp(argv[i], "-double_cover") == 0) {
+			f_double_cover = true;
+			double_cover_label.assign(argv[++i]);
+			if (f_v) {
+				cout << "-double_cover "
+						<< double_cover_label << endl;
+			}
+		}
+
 
 		else if (M.check_and_parse_argument(
 				argc, i, argv,
@@ -567,6 +579,9 @@ void create_graph_description::print()
 	}
 	if (f_Cayley_graph) {
 		cout << "-Cayley_graph " << Cayley_graph_group << " " << Cayley_graph_gens << endl;
+	}
+	if (f_double_cover) {
+		cout << "-double_cover " << double_cover_label << endl;
 	}
 
 	int i;

--- a/src/lib/layer5_top_level/apps_graph_theory/tl_graph_theory.h
+++ b/src/lib/layer5_top_level/apps_graph_theory/tl_graph_theory.h
@@ -233,6 +233,9 @@ public:
 	std::string Cayley_graph_group;
 	std::string Cayley_graph_gens;
 
+	int f_double_cover;
+	std::string double_cover_label;
+
 	std::vector<graph_modification_description> Modifications;
 
 	create_graph_description();
@@ -342,6 +345,9 @@ public:
 			int verbose_level);
 	void make_adjacency_bitvector(
 			std::string &data_text, int N,
+			int verbose_level);
+	void create_double_cover(
+			std::string &graph_label,
 			int verbose_level);
 
 };


### PR DESCRIPTION
## Summary

- Implements `-double_cover <label>` as a new graph construction command in Orbiter
- Given a graph Γ = (V, E), creates Γ' with two copies of V plus one extra vertex z, where z is adjacent to all vertices in one copy but not the other
- Adds `create_double_cover` to `create_graph`, parsing in `create_graph_description`, and declaration in `tl_graph_theory.h`
- Also includes minor updates to quartic curve files

## Test

Starting from G₀ = ({x}, ∅) and iterating Gᵢ₊₁ = Γ'(Gᵢ):

| Graph | Vertices | \|Aut\| |
|-------|----------|---------|
| G₀ | 1 | 1 |
| G₁ | 3 | 2 |
| G₂ | 7 | 4 |
| G₃ | 15 | 16 |
| G₄ | 31 | 256 |
| G₅ | 63 | 65536 |

Pattern: \|V(Gᵢ)\| = 2^(i+1) − 1, \|Aut(Gᵢ)\| = 2^(2^(i−1)) for i ≥ 1.