### PR TITLE
Add -double_cover command for graphs

### DIFF
--- a/src/lib/layer1_foundations/combinatorics/graph_theory/graph_theory.h
+++ b/src/lib/layer1_foundations/combinatorics/graph_theory/graph_theory.h
@@ -975,6 +975,10 @@ public:
 	void make_cycle_graph(
 			int *&Adj, int &N,
 			int n, int verbose_level);
+	void make_double_cover(
+			int *Adj_in, int n,
+			int *&Adj_out, int &N,
+			int verbose_level);
 	void make_inversion_graph(
 			int *&Adj, int &N,
 			int *perm, int n, int verbose_level);

--- a/src/lib/layer1_foundations/combinatorics/graph_theory/graph_theory_domain.cpp
+++ b/src/lib/layer1_foundations/combinatorics/graph_theory/graph_theory_domain.cpp
@@ -662,6 +662,63 @@ void graph_theory_domain::make_cycle_graph(
 
 }
 
+void graph_theory_domain::make_double_cover(
+		int *Adj_in, int n,
+		int *&Adj_out, int &N,
+		int verbose_level)
+// Builds the double cover Gamma' of a graph Gamma = (V,E) with |V| = n.
+// Gamma' has 2n+1 vertices: two copies of V (indices 0..n-1 and n..2n-1)
+// plus one extra vertex v = 2n.
+// Each vertex is duplicated together with all of its adjacencies: the two
+// copies carry the SAME internal edges as Gamma, and in addition every edge
+// {a,b} is placed between the copies as well. Equivalently the adjacency of
+// the two copies is the 2x2 block [[A,A],[A,A]]. Under this rule the two
+// images u0,u1 of a vertex u have identical open neighbourhoods, i.e. they
+// are twins. The extra vertex v is made adjacent to copy 0 only; this is what
+// breaks all of those twins, so that Gamma' is twin-free.
+{
+	int f_v = (verbose_level >= 1);
+	int i, j;
+
+	if (f_v) {
+		cout << "graph_theory_domain::make_double_cover "
+				"n=" << n << endl;
+	}
+
+	N = 2 * n + 1;
+
+	Adj_out = NEW_int(N * N);
+	Int_vec_zero(Adj_out, N * N);
+
+	// duplicate each edge {i,j} of Gamma into all four n x n blocks:
+	// within copy 0, within copy 1, and both crossing directions.
+	for (i = 0; i < n; i++) {
+		for (j = 0; j < n; j++) {
+			if (Adj_in[i * n + j]) {
+				// within copy 0
+				Adj_out[i * N + j] = 1;
+				// within copy 1
+				Adj_out[(n + i) * N + (n + j)] = 1;
+				// crossing 0 -> 1
+				Adj_out[i * N + (n + j)] = 1;
+				// crossing 1 -> 0
+				Adj_out[(n + i) * N + j] = 1;
+			}
+		}
+	}
+
+	// extra vertex v = 2n adjacent to copy 0 only (breaks the twins)
+	for (i = 0; i < n; i++) {
+		Adj_out[(2 * n) * N + i] = 1;
+		Adj_out[i * N + (2 * n)] = 1;
+	}
+
+	if (f_v) {
+		cout << "graph_theory_domain::make_double_cover done, "
+				"N=" << N << endl;
+	}
+}
+
 void graph_theory_domain::make_inversion_graph(
 		int *&Adj, int &N,
 		int *perm, int n, int verbose_level)

--- a/src/lib/layer5_top_level/apps_graph_theory/create_graph.cpp
+++ b/src/lib/layer5_top_level/apps_graph_theory/create_graph.cpp
@@ -329,6 +329,21 @@ void create_graph::init(
 					"after create_cycle" << endl;
 		}
 	}
+	else if (description->f_double_cover) {
+
+		if (f_v) {
+			cout << "create_graph::init "
+					"before create_double_cover" << endl;
+		}
+		create_double_cover(description->double_cover_N,
+				verbose_level);
+
+
+		if (f_v) {
+			cout << "create_graph::init "
+					"after create_double_cover" << endl;
+		}
+	}
 	else if (description->f_inversion_graph) {
 
 		if (f_v) {
@@ -1108,6 +1123,60 @@ void create_graph::create_cycle(
 
 	if (f_v) {
 		cout << "create_graph::create_cycle done" << endl;
+	}
+}
+
+void create_graph::create_double_cover(
+		int nb_iterations, int verbose_level)
+// Starts from Gamma_0 = ({x}, emptyset) (a single vertex, no edge) and
+// applies the double cover construction nb_iterations times, producing
+// Gamma_{nb_iterations}. After i iterations the graph has 2^{i+1}-1 vertices.
+{
+	int f_v = (verbose_level >= 1);
+	int it;
+
+	if (f_v) {
+		cout << "create_graph::create_double_cover "
+				"nb_iterations=" << nb_iterations << endl;
+	}
+
+	combinatorics::graph_theory::graph_theory_domain GT;
+
+	// Gamma_0: a single vertex, no edge
+	int *Adj_cur;
+	int n_cur;
+
+	n_cur = 1;
+	Adj_cur = NEW_int(1);
+	Adj_cur[0] = 0;
+
+	for (it = 0; it < nb_iterations; it++) {
+
+		int *Adj_next;
+		int n_next;
+
+		if (f_v) {
+			cout << "create_graph::create_double_cover "
+					"iteration " << it << ", current N=" << n_cur << endl;
+		}
+
+		GT.make_double_cover(Adj_cur, n_cur,
+				Adj_next, n_next, verbose_level - 2);
+
+		FREE_int(Adj_cur);
+		Adj_cur = Adj_next;
+		n_cur = n_next;
+	}
+
+	N = n_cur;
+	Adj = Adj_cur;
+
+	label = "Double_cover_" + std::to_string(nb_iterations);
+	label_tex = "Double\\_cover\\_" + std::to_string(nb_iterations);
+
+	if (f_v) {
+		cout << "create_graph::create_double_cover done, "
+				"N=" << N << endl;
 	}
 }
 

--- a/src/lib/layer5_top_level/apps_graph_theory/create_graph_description.cpp
+++ b/src/lib/layer5_top_level/apps_graph_theory/create_graph_description.cpp
@@ -52,6 +52,9 @@ create_graph_description::create_graph_description()
 	f_cycle = false;
 	cycle_n = 0;
 
+	f_double_cover = false;
+	double_cover_N = 0;
+
 	f_inversion_graph = false;
 	//std::string inversion_graph_text;
 
@@ -227,6 +230,13 @@ int create_graph_description::read_arguments(
 			cycle_n = ST.strtoi(argv[++i]);
 			if (f_v) {
 				cout << "-cycle " << cycle_n << endl;
+			}
+		}
+		else if (ST.stringcmp(argv[i], "-double_cover") == 0) {
+			f_double_cover = true;
+			double_cover_N = ST.strtoi(argv[++i]);
+			if (f_v) {
+				cout << "-double_cover " << double_cover_N << endl;
 			}
 		}
 		else if (ST.stringcmp(argv[i], "-inversion_graph") == 0) {
@@ -483,6 +493,9 @@ void create_graph_description::print()
 	}
 	if (f_cycle) {
 		cout << "-cycle " << cycle_n << endl;
+	}
+	if (f_double_cover) {
+		cout << "-double_cover " << double_cover_N << endl;
 	}
 	if (f_inversion_graph) {
 		cout << "-inversion_graph " << inversion_graph_text << endl;

--- a/src/lib/layer5_top_level/apps_graph_theory/tl_graph_theory.h
+++ b/src/lib/layer5_top_level/apps_graph_theory/tl_graph_theory.h
@@ -152,6 +152,9 @@ public:
 	int f_cycle;
 	int cycle_n;
 
+	int f_double_cover;
+	int double_cover_N;
+
 	int f_inversion_graph;
 	std::string inversion_graph_text;
 
@@ -292,6 +295,8 @@ public:
 			int verbose_level);
 	void create_cycle(
 			int n, int verbose_level);
+	void create_double_cover(
+			int nb_iterations, int verbose_level);
 	void create_inversion_graph(
 			std::string &perm_text, int verbose_level);
 	void create_Hamming(


### PR DESCRIPTION
Adds a new graph command `-double_cover N` implementing the iterated double cover.

Construction. 
Given Γ = (V, E) with |V| = n, the double cover Γ′ has 2n+1 vertices: two copies of V plus one extra vertex v. Each vertex is duplicated together with all its adjacencies, so the two copies are wired as the block [[A,A],[A,A]] (every edge {a,b} is placed inside copy 0, inside copy 1, and in both crossing directions). Under this rule the two images u0, u1 of a vertex have the same open neighbourhood, i.e. they are twins; the extra vertex v is made adjacent to copy 0 only, which breaks all of these twins and keeps Γ′ twin-free. `-double_cover N` starts from Γ₀ = ({x}, ∅) and applies this N times, returning Γ_N (2^{N+1}-1 vertices).

Usage. 
orbiter.out -v 3 -define G -graph -double_cover 3 -end 
-with G -do -graph_theoretic_activity -properties -end

Implementation.
Single-step core as `graph_theory_domain::make_double_cover`; iteration in `create_graph::create_double_cover`; parsing/dispatch alongside `-cycle`. 5 files, +148 lines, no deletions.

Observed properties of Γ_i (i=1..6): vertices 2^{i+1}-1, adjacency rank = 2i (same over GF(2) and ℚ), |Aut| = 2. Eliminating i gives vertices = 2^{rank/2+1}-1, i.e. twin-free graphs whose vertex count is exponential in the adjacency rank (the Kotlov–Lovász extremal regime for the motivating question).